### PR TITLE
notmuch: update to 0.39.

### DIFF
--- a/srcpkgs/notmuch/notmuch-python3.INSTALL.msg
+++ b/srcpkgs/notmuch/notmuch-python3.INSTALL.msg
@@ -1,0 +1,3 @@
+The legacy python bindings in this package have been deprecated and
+are unsupported by notmuch, and will likely be phased out in upcoming
+releases. Please switch to the new cffi bindings in python3-notmuch2.

--- a/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
+++ b/srcpkgs/notmuch/patches/0008-fix-cross-for-ruby-bindings.patch
@@ -1,0 +1,35 @@
+diff --git a/bindings/ruby/extconf.rb b/bindings/ruby/extconf.rb
+index d914537c..aae1d2fd 100644
+--- a/bindings/ruby/extconf.rb
++++ b/bindings/ruby/extconf.rb
+@@ -18,9 +18,30 @@ if not ENV['LIBNOTMUCH']
+   exit 1
+ end
+ 
++# Use cross-compiler toolchain
++if ENV['_TARGET_PLATFORM']
++  RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
++  RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
++  RbConfig::MAKEFILE_CONFIG['LD'] = ENV['LD'] if ENV['LD']
++  RbConfig::MAKEFILE_CONFIG['AR'] = ENV['AR'] if ENV['AR']
++  RbConfig::MAKEFILE_CONFIG['CFLAGS'] = ENV['CFLAGS'] if ENV['CFLAGS']
++  RbConfig::MAKEFILE_CONFIG['LDFLAGS'] = ENV['LDFLAGS'] if ENV['LDFLAGS']
++end
++
+ $LOCAL_LIBS += ENV['LIBNOTMUCH']
+ $LIBS += " -ltalloc"
+ 
+ # Create Makefile
+ dir_config('notmuch')
+ create_makefile('notmuch')
++
++# Fix makefile definitions for cross compile
++if ENV['_TARGET_PLATFORM']
++  system("sed -i 's|^V =.*|V = 1|' Makefile")
++  system("sed -i 's|^CFLAGS.*|CFLAGS = \$(CCDLFLAGS) $(VOID_TARGET_CFLAGS) \$(ARCH_FLAG)|' Makefile")
++  system("sed -i 's|^topdir.*|topdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)|' Makefile")
++  system("sed -i 's|^hdrdir.*|hdrdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)|' Makefile")
++  system("sed -i 's|^arch_hdrdir.*|arch_hdrdir = $(XBPS_CROSS_BASE)/usr/include/ruby-\$(ruby_version)/\$(arch)|' Makefile")
++  system("sed -i 's|^arch =.*|arch = $(_TARGET_PLATFORM)|' Makefile")
++  system("sed -i 's|^dldflags =.*|dldflags = $(LDFLAGS)|' Makefile")
++end

--- a/srcpkgs/notmuch/patches/0009-test-emacs-switch-to-tmux.patch
+++ b/srcpkgs/notmuch/patches/0009-test-emacs-switch-to-tmux.patch
@@ -1,0 +1,25 @@
+diff --git a/test/test-lib-emacs.sh b/test/test-lib-emacs.sh
+index 0ab58fc2..068dae16 100644
+--- a/test/test-lib-emacs.sh
++++ b/test/test-lib-emacs.sh
+@@ -18,7 +18,7 @@ test_require_emacs () {
+     local ret=0
+     test_require_external_prereq "$TEST_EMACS" || ret=1
+     test_require_external_prereq "$TEST_EMACSCLIENT" || ret=1
+-    test_require_external_prereq dtach || ret=1
++    test_require_external_prereq tmux || ret=1
+     return $ret
+ }
+ 
+@@ -187,10 +187,7 @@ test_emacs () {
+ 		fi
+ 		server_name="notmuch-test-suite-$$"
+ 		# start a detached session with an emacs server
+-		# user's TERM (or 'vt100' in case user's TERM is known dumb
+-		# or unknown) is given to dtach which assumes a minimally
+-		# VT100-compatible terminal -- and emacs inherits that
+-		TERM=$SMART_TERM dtach -n "$TEST_TMPDIR/emacs-dtach-socket.$$" \
++		TERM=$SMART_TERM tmux new-session -d -s emacs-session-"$$" \
+ 			sh -c "stty rows 24 cols 80; exec '$TMP_DIRECTORY/run_emacs' \
+ 				--no-window-system \
+ 				$load_emacs_tests \

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,18 +1,19 @@
 # Template file for 'notmuch'
 pkgname=notmuch
-version=0.38
-revision=4
+version=0.39
+revision=1
 build_style=configure
 build_helper=python3
 configure_args="--prefix=/usr
  --emacslispdir=/usr/share/emacs/site-lisp/notmuch
  --emacsetcdir=/usr/share/emacs/site-lisp/notmuch"
 hostmakedepends="perl pkg-config python3-Sphinx python3-devel texinfo
- desktop-file-utils emacs gnupg python3-setuptools python3-cffi"
+ desktop-file-utils emacs gnupg python3-setuptools python3-cffi
+ python3-build python3-installer doxygen ruby-devel"
 makedepends="bash-completion gmime3-devel talloc-devel xapian-core-devel
- python3-cffi"
+ python3-cffi ruby-devel"
 depends="gmime3>=3.2.7"
-checkdepends="python3-pytest mdocml dtach gdb tar xz xapian-core
+checkdepends="python3-pytest mdocml tmux gdb tar xz xapian-core
  openssl"
 short_desc="Thread-based email index, search, and tagging"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -20,7 +21,7 @@ license="GPL-3.0-or-later"
 homepage="https://notmuchmail.org"
 distfiles="https://notmuchmail.org/releases/notmuch-${version}.tar.xz
  https://notmuchmail.org/releases/test-databases/database-v1.tar.xz"
-checksum="a17901adbe43f481a6bf53c15a2a20268bc8dc7ad5ccf685a0d17c1456dbaf6e
+checksum="b88bb02a76c46bad8d313fd2bb4f8e39298b51f66fcbeb304d9f80c3eef704e3
  4299e051b10e1fa7b33ea2862790a09ebfe96859681804e5251e130f800e69d2"
 skip_extraction="database-v1.tar.xz"
 replaces="notmuch-emacs>=0"
@@ -29,20 +30,22 @@ replaces="notmuch-emacs>=0"
 # gpgme is optional dependency
 conflicts="gpgme<1.14.0_1"
 subpackages="libnotmuch libnotmuch-devel notmuch-mutt
- notmuch-python3 python3-notmuch2"
-
-if [ ! "$CROSS_BUILD" ]; then
-	makedepends+=" ruby-devel"
-	subpackages+=" notmuch-ruby"
-fi
+ notmuch-python3 python3-notmuch2 notmuch-ruby"
 
 do_build() {
+	if [ "$CROSS_BUILD" ]; then
+		_TARGET_PLATFORM="$(ruby -r \
+			$(find ${XBPS_CROSS_BASE}/usr/lib/ruby -iname rbconfig.rb) \
+			-e 'puts RbConfig::CONFIG["arch"]' 2>/dev/null)"
+		VOID_TARGET_CFLAGS="$CFLAGS"
+		export _TARGET_PLATFORM XBPS_CROSS_BASE VOID_TARGET_CFLAGS
+	fi
 	make ${makejobs}
 	make -C contrib/notmuch-mutt
-	cd ${wrksrc}/bindings/python
-	python3 setup.py build --build-base=build
 	cd ${wrksrc}/bindings/python-cffi
-	python3 setup.py build --build-base=build
+	python -m build --wheel --skip-dependency-check --no-isolation
+	cd ${wrksrc}/contrib/python-legacy
+	python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 do_check() {
@@ -51,17 +54,14 @@ do_check() {
 		# Seem like gpgconf's problem,
 		# mutt on musl also have problems with smime
 		NOTMUCH_SKIP_TESTS="smime.3 smime.5"
-	else
-		# This test run under gdb is problematic
-		NOTMUCH_SKIP_TESTS="count.14"
+		# bad regex test fails on musl
+		NOTMUCH_SKIP_TESTS+=" as-text.10"
 	fi
-	# libconfig because of fqdn
-	# we don't ship python-cffi
-	NOTMUCH_SKIP_TESTS+=" libconfig python-cffi"
-	NOTMUCH_SKIP_TESTS+=" crypto index-decryption"
 	if [ $(id -u) = 0 ]; then
 		NOTMUCH_SKIP_TESTS+=" new.36 new.39 tagging.25"
 	fi
+	# fails due to our gmime configure patches
+	NOTMUCH_SKIP_TESTS+=" smime.4"
 	export NOTMUCH_SKIP_TESTS
 	make test
 }
@@ -84,6 +84,7 @@ libnotmuch-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/*.so
+		vmove usr/share/man/man3
 	}
 }
 
@@ -99,27 +100,32 @@ notmuch-mutt_package() {
 
 notmuch-python3_package() {
 	depends="libnotmuch python3"
-	short_desc+=" - Python 3 bindings"
+	short_desc+=" - Python 3 bindings (legacy)"
 	pkg_install() {
-		cd ${wrksrc}/bindings/python
-		python3 setup.py build --build-base=build \
-			install --prefix=/usr --root=${PKGDESTDIR}
+		cd ${wrksrc}/contrib/python-legacy
+		python -m installer --destdir="$PKGDESTDIR" dist/*.whl
 	}
 }
 
 python3-notmuch2_package() {
-	depends="libnotmuch python3"
+	depends="libnotmuch python3 python3-cffi"
 	short_desc+=" - Python 3 cffi bindings"
 	pkg_install() {
 		cd ${wrksrc}/bindings/python-cffi
-		python3 setup.py build --build-base=build \
-			install --prefix=/usr --root=${PKGDESTDIR}
+		python -m installer --destdir="$PKGDESTDIR" dist/*.whl
 	}
 }
 
 notmuch-ruby_package() {
 	short_desc+=" - Ruby bindings"
 	pkg_install() {
+		if [ "$CROSS_BUILD" ]; then
+			_TARGET_PLATFORM="$(ruby -r \
+				$(find ${XBPS_CROSS_BASE}/usr/lib/ruby -iname rbconfig.rb) \
+				-e 'puts RbConfig::CONFIG["arch"]' 2>/dev/null)"
+			VOID_TARGET_CFLAGS="$CFLAGS"
+			export _TARGET_PLATFORM XBPS_CROSS_BASE VOID_TARGET_CFLAGS
+		fi
 		make DESTDIR=${PKGDESTDIR} -C bindings/ruby install
 	}
 }


### PR DESCRIPTION
notmuch: unmask passing tests

notmuch: allow cross for notmuch-ruby

notmuch: fix emacs tests for ci

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
